### PR TITLE
Resiliency improvements

### DIFF
--- a/lib/hermoth.js
+++ b/lib/hermoth.js
@@ -180,12 +180,10 @@ class Hermoth {
       this.log.info(`Received message [name=${message.name}, id=${message.id}] from queue ` +
         `[${this.createdQueueName}]`)
 
-      const ackCallback = this.channel.ack(originalMessage)
-      // const ackCallback = () => this.channel.ack(originalMessage)
+      const ackCallback = () => this.channel.ack(originalMessage)
       await Promise.all(
         this.listeners[message.name]
-          .map(listener => Promise.resolve(listener.call(this, message, () => ackCallback))),
-          // .map(listener => Promise.resolve(listener.call(this, message, ackCallback))),
+          .map(listener => Promise.resolve(listener.call(this, message, ackCallback))),
       )
     }
   }

--- a/lib/hermoth.js
+++ b/lib/hermoth.js
@@ -66,7 +66,7 @@ class Hermoth {
     const queueOptions = {
       exclusive: this.exclusiveQueue,
       persistent: this.durableQueue,
-      autoDelete: this.exclusiveQueue && !this.durableQueue
+      autoDelete: this.exclusiveQueue && !this.durableQueue,
     }
     const queue = await this.channel.assertQueue(this.queueName, queueOptions)
     this.createdQueueName = queue.queue
@@ -76,8 +76,9 @@ class Hermoth {
     this.channel.bindQueue(this.createdQueueName, this.exchangeName, this.queueBindingKey)
     this.log.info(`Bound queue [${this.createdQueueName}] to the exchange [${this.exchangeName}] ` +
       `with key ${this.queueBindingKey} `)
-    this.channel.consume(queue.queue, this.consume.bind(this), { noAck: this.noAck })
+
     this.restartInProgress = false
+    return this.channel.consume(queue.queue, this.consume.bind(this), { noAck: this.noAck })
   }
 
   /**
@@ -100,8 +101,8 @@ class Hermoth {
         connected = false
         tries += 1
         this.log.error('Failed to connect to exchange ' +
-          `[host=${this.endpointToStr()},name=${this.exchangeName},queue=${this.queueName}]:
-            ${err.code}. ${this.retryConnection ? `Retrying in ${this.connectionRetryDelayInMs / 1000} seconds..` : ''} ` +
+          `[host=${this.endpointToStr()},name=${this.exchangeName},queue=${this.queueName}]: ${err.code}.` +
+          `${this.retryConnection ? `Retrying in ${this.connectionRetryDelayInMs / 1000} seconds..` : ''} ` +
           `(attempt ${tries}/${this.maxConnectionRetries})`)
         if (tries <= this.maxConnectionRetries) {
           await delay(this.connectionRetryDelayInMs) // eslint-disable-line no-await-in-loop

--- a/lib/hermoth.js
+++ b/lib/hermoth.js
@@ -40,6 +40,7 @@ class Hermoth {
 
     this.listeners = {}
     this.createdQueueName = null
+    this.restartInProgress = false
   }
 
   /**
@@ -49,13 +50,11 @@ class Hermoth {
    * @return {Promise}
    */
   async init() {
-    const conn = await this.connectToMessageBroker(this.host, this.connectionRetryDelayInMs)
-    conn.once('close', () => {
-      this.log.error('Connection to message broker lost, trying to reconnect..')
-      return this.init(this.host, this.exchangeName)
-    })
+    this.conn = await this.connectToMessageBroker(this.host, this.connectionRetryDelayInMs)
+    this.conn.on('close', this.handleConnectionClose.bind(this))
 
-    this.channel = await conn.createChannel()
+    this.channel = await this.conn.createChannel()
+    this.channel.on('error', this.handleChannelClose.bind(this))
 
     if (this.exchangeType) { // If we won't use the default exchange
       // Create the exchange if it doesn't exist
@@ -64,7 +63,11 @@ class Hermoth {
     }
 
     // Create queue if it doesn't exist. All messages are received from this queue.
-    const queueOptions = { exclusive: this.exclusiveQueue, persistent: this.durableQueue }
+    const queueOptions = {
+      exclusive: this.exclusiveQueue,
+      persistent: this.durableQueue,
+      autoDelete: this.exclusiveQueue && !this.durableQueue
+    }
     const queue = await this.channel.assertQueue(this.queueName, queueOptions)
     this.createdQueueName = queue.queue
     this.log.info(`Connected to queue [${this.createdQueueName}]`)
@@ -73,8 +76,8 @@ class Hermoth {
     this.channel.bindQueue(this.createdQueueName, this.exchangeName, this.queueBindingKey)
     this.log.info(`Bound queue [${this.createdQueueName}] to the exchange [${this.exchangeName}] ` +
       `with key ${this.queueBindingKey} `)
-
-    return this.channel.consume(queue.queue, this.consume.bind(this), { noAck: this.noAck })
+    this.channel.consume(queue.queue, this.consume.bind(this), { noAck: this.noAck })
+    this.restartInProgress = false
   }
 
   /**
@@ -92,12 +95,13 @@ class Hermoth {
       try {
         conn = await connect(this.host) // eslint-disable-line no-await-in-loop
         connected = true
-        this.log.info(`Connected to message broker ${this.endpointToStr()} `)
+        this.log.info(`Connected to message broker [${this.endpointToStr()}]`)
       } catch (err) {
         connected = false
         tries += 1
-        this.log.error(`Failed to connect to ${this.endpointToStr()}: ${err.code}. ${this.retryConnection ?
-          `Retrying in ${this.connectionRetryDelayInMs / 1000} seconds..` : ''} ` +
+        this.log.error('Failed to connect to exchange ' +
+          `[host=${this.endpointToStr()},name=${this.exchangeName},queue=${this.queueName}]:
+            ${err.code}. ${this.retryConnection ? `Retrying in ${this.connectionRetryDelayInMs / 1000} seconds..` : ''} ` +
           `(attempt ${tries}/${this.maxConnectionRetries})`)
         if (tries <= this.maxConnectionRetries) {
           await delay(this.connectionRetryDelayInMs) // eslint-disable-line no-await-in-loop
@@ -164,24 +168,67 @@ class Hermoth {
    * @param  {originalMessage} - AMPQ Message}
    */
   async consume(originalMessage) {
-    const message = parseMessage(originalMessage)
+    let message
+    try {
+      message = parseMessage(originalMessage)
+    } catch (e) {
+      this.log.error(`Invalid message: ${originalMessage}`)
+      return
+    }
 
     if (this.listeners[message.name]) {
       this.log.info(`Received message [name=${message.name}, id=${message.id}] from queue ` +
         `[${this.createdQueueName}]`)
 
       const ackCallback = this.channel.ack(originalMessage)
-
+      // const ackCallback = () => this.channel.ack(originalMessage)
       await Promise.all(
         this.listeners[message.name]
           .map(listener => Promise.resolve(listener.call(this, message, () => ackCallback))),
+          // .map(listener => Promise.resolve(listener.call(this, message, ackCallback))),
       )
     }
   }
 
+  async handleConnectionClose(err) {
+    if (this.restartInProgress) {
+      this.log.warn('Ignoring closed connection as another handler initiated a restart already')
+      return
+    }
+    this.restartInProgress = true
+    this.log.error('Connection to message broker lost, trying to reconnect..\n', err)
+
+    try {
+      await this.channel.close()
+      this.log.info('Channel successfully closed')
+    } catch (alreadyClosed) {
+      this.log.warn('Channel was already closed', alreadyClosed.stackAtStateChange)
+    }
+
+    this.init()
+  }
+
+  async handleChannelClose(err) {
+    if (this.restartInProgress) {
+      this.log.warn('Ignoring closed channel as another handler initiated a restart already')
+      return
+    }
+    this.restartInProgress = true
+    this.log.error('Re-creating the channel as it was closed with reason:\n', err)
+
+
+    try {
+      await this.conn.close()
+      this.log.info('Connection successfully closed')
+    } catch (alreadyClosed) {
+      this.log.warn('Connection was already closed', alreadyClosed.stackAtStateChange)
+    }
+
+    this.init()
+  }
+
   endpointToStr() {
-    const endpoint = this.host.includes('@') ? this.host.split('@')[1] : this.host
-    return `[${endpoint}]`
+    return this.host.includes('@') ? this.host.split('@')[1] : this.host
   }
 
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,17 +19,17 @@ export class PrefixedLogger { // eslint-disable-line import/prefer-default-expor
 }
 
 export const parseMessage = (msg) => {
-  const content = msg.content
+  const content = msg ? msg.content : null
 
   let message
   try {
     message = JSON.parse(content)
   } catch (err) {
     throw new Error(`Unable to parse the message to JSON!
-        Message was: ${content},
+        Message content was: ${content},
         Original error is ${err}`)
   }
-  if (!message.id || !message.name || !message.payload) {
+  if (!message || !message.id || !message.name || !message.payload) {
     throw new Error(`Message doesn't have some of [id,name,payload]: ${message}`)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hermoth",
-  "version": "2.1.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermoth",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A wrapper for the publish/subscribe messaging pattern on top of an AMQP-compatible message broker",
   "main": "src/hermoth",
   "directories": {

--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,7 @@ describe('hermoth', () => {
 
     beforeEach(() => {
       channelStub = {
+        on: sinon.stub(),
         assertExchange: sinon.stub(),
         assertQueue: sinon.stub().returns({ queue: 'my_queue' }),
         bindQueue: sinon.stub(),
@@ -104,7 +105,7 @@ describe('hermoth', () => {
       }
 
       connectStub = {
-        once: sinon.stub(),
+        on: sinon.stub(),
         createChannel: sinon.stub().returns(channelStub),
       }
     })
@@ -119,7 +120,7 @@ describe('hermoth', () => {
       sinon.assert.calledWith(channelStub.assertExchange,
         hermoth.exchangeName, hermoth.exchangeType, { durable: hermoth.durableExchange })
       sinon.assert.calledWith(channelStub.assertQueue, hermoth.queueName,
-        { exclusive: hermoth.exclusiveQueue, persistent: hermoth.durableQueue })
+        { autoDelete: true, exclusive: hermoth.exclusiveQueue, persistent: hermoth.durableQueue })
       sinon.assert.calledWith(channelStub.bindQueue,
         hermoth.queueName, hermoth.exchangeName, hermoth.queueBindingKey)
       sinon.assert.calledWith(channelStub.consume,

--- a/test/test.js
+++ b/test/test.js
@@ -227,7 +227,7 @@ describe('hermoth', () => {
       const handleChannelClose = sinon.spy()
       channelStub.on('error', handleChannelClose)
 
-      const error = new Error('Connection closed: 320 CONNECTION_FORCED - broker forced connection closure')
+      const error = new Error('Channel closed by server: 406 PRECONDITION_FAILED - unknown delivery tag 1')
       channelStub.emit('error', error)
 
       sinon.assert.calledOnce(handleChannelClose)

--- a/test/test.js
+++ b/test/test.js
@@ -5,12 +5,12 @@ import Hermoth from '../lib/hermoth'
 
 const EventEmitter = require('events')
 
+class Channel extends EventEmitter { }
+class Connection extends EventEmitter { }
+
 const AMQP_ENDPOINT_URL = 'amqp://0.0.0.0:5672'
 const AMQP_EXCHANGE_NAME = 'test_exchange'
 const EVENT_NAME = 'foo:info'
-
-class Channel extends EventEmitter { }
-class Connection extends EventEmitter { }
 
 describe('hermoth', () => {
   const logger = {


### PR DESCRIPTION
# Description

- Passes `ack` to the function instead of actually calling it 🤦‍♂️
- Added resiliency in case connection with message broker is lost
- Added resiliency in case the channel dies. AMQP (hence RabbitMQ) seems quite unforgiving for actions that looks suspicious: ack when you don't supposed to, double ack, or ack in the wrong channel etc it kills the channel completely. Try to unbind when there is no such binding: kills the connection. Stuff like that.

# Related PRs
https://velocityapp.atlassian.net/browse/VOS-1353

# Checklist

- [x] Go over all file changes one final time
- [x] Confirm there are tests covering the changes on this PR
- [x] Confirm the build passes on Circle CI

![](http://thecatapi.com/api/images/get?format=src&type=gif)
