### PR TITLE
Allow multiple queue binding keys

### DIFF
--- a/lib/hermoth.js
+++ b/lib/hermoth.js
@@ -21,7 +21,7 @@ class Hermoth {
     durableQueue = false,
     persistentMessages = false,
     exclusiveQueue = false,
-    queueBindingKey = '#',
+    queueBindingKeys = ['#'],
     noAck = true,
   }) {
     this.host = host
@@ -35,7 +35,7 @@ class Hermoth {
     this.durableQueue = durableQueue
     this.persistentMessages = persistentMessages
     this.exclusiveQueue = exclusiveQueue
-    this.queueBindingKey = queueBindingKey
+    this.queueBindingKeys = queueBindingKeys
     this.noAck = noAck
 
     this.listeners = {}
@@ -72,10 +72,12 @@ class Hermoth {
     this.createdQueueName = queue.queue
     this.log.info(`Connected to queue [${this.createdQueueName}]`)
 
-    // Bind the queue to the exchange so that it can receive messages from it
-    this.channel.bindQueue(this.createdQueueName, this.exchangeName, this.queueBindingKey)
-    this.log.info(`Bound queue [${this.createdQueueName}] to the exchange [${this.exchangeName}] ` +
-      `with key ${this.queueBindingKey} `)
+    for (const queueBindingKey of this.queueBindingKeys) { // eslint-disable-line no-restricted-syntax
+      // Bind the queue to the exchange so that it can receive messages from it
+      this.channel.bindQueue(this.createdQueueName, this.exchangeName, queueBindingKey)
+      this.log.info(`Bound queue [${this.createdQueueName}] to the exchange [${this.exchangeName}] ` +
+        `with key [${queueBindingKey}]`)
+    }
 
     this.restartInProgress = false
     return this.channel.consume(queue.queue, this.consume.bind(this), { noAck: this.noAck })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermoth",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A wrapper for the publish/subscribe messaging pattern on top of an AMQP-compatible message broker",
   "main": "src/hermoth",
   "directories": {

--- a/test/test.js
+++ b/test/test.js
@@ -31,7 +31,7 @@ describe('hermoth', () => {
       maxConnectionRetries: 1,
       durableExchange: false,
       exclusiveQueue: true,
-      queueBindingKey: '.',
+      queueBindingKeys: ['.'],
       noAck: true,
     }, overrideOptions)
     return new Hermoth(args)
@@ -67,7 +67,7 @@ describe('hermoth', () => {
         durableQueue: true,
         persistentMessages: true,
         exclusiveQueue: true,
-        queueBindingKey: '.',
+        queueBindingKeys: ['*.bletchley.*', '*.*.park', 'cambridge.#'],
         noAck: true,
       }
       const hermoth = hermothFactory(options)
@@ -82,7 +82,7 @@ describe('hermoth', () => {
       assert.equal(true, hermoth.durableQueue)
       assert.equal(true, hermoth.persistentMessages)
       assert.equal(true, hermoth.exclusiveQueue)
-      assert.equal('.', hermoth.queueBindingKey)
+      assert.deepEqual(['*.bletchley.*', '*.*.park', 'cambridge.#'], hermoth.queueBindingKeys)
       assert.equal(true, hermoth.noAck)
     })
   })
@@ -123,8 +123,10 @@ describe('hermoth', () => {
         hermoth.exchangeName, hermoth.exchangeType, { durable: hermoth.durableExchange })
       sinon.assert.calledWith(channelStub.assertQueue, hermoth.queueName,
         { autoDelete: true, exclusive: hermoth.exclusiveQueue, persistent: hermoth.durableQueue })
-      sinon.assert.calledWith(channelStub.bindQueue,
-        hermoth.queueName, hermoth.exchangeName, hermoth.queueBindingKey)
+      for (const bindingKey of hermoth.queueBindingKeys) { // eslint-disable-line no-restricted-syntax
+        sinon.assert.calledWith(channelStub.bindQueue,
+          hermoth.queueName, hermoth.exchangeName, bindingKey)
+      }
       sinon.assert.calledWith(channelStub.consume,
         hermoth.queueName, sinon.match.func, { noAck: hermoth.noAck })
     })


### PR DESCRIPTION
# Description
Allow queues bind to multiple message types.

The problem now is that service queues (like `bookings`) receive all messages, but only listen to a specific one and acknowledge that message. This results in many unacknowledged messages (count = # of type of messages - 1)

The service queues can now bind with to one or more keys, so that the service queue will only receive the messages that it wants to process & acknowledge.

# Related PRs
https://github.com/VelocityMobile/erb-services-audit/pull/14
https://github.com/VelocityMobile/erb-services-bookings/pull/208

# TODOs
Increment `hermoth` version that's used

# Checklist

- [x] Go over all file changes one final time
- [x] Confirm there are tests covering the changes on this PR
- [x] Confirm the build passes on Circle CI

![](http://thecatapi.com/api/images/get?format=src&type=gif)
